### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,12 +6,18 @@ queue_rules:
       - label=Ready to merge
 
 pull_request_rules:
-  - name: Automatic merge on approval
-    conditions: *default_queue_conditions
+  - name: Automatically approve Dependabot PRs
+    conditions:
+      - author=dependabot[bot]
+      - or:
+        - dependabot-update-type=version-update:semver-minor
+        - dependabot-update-type=version-update:semver-patch
     actions:
-      queue:
-        name: default
-        allow_merging_configuration_change: true
+      review:
+        type: APPROVE
+      label:
+        add:
+          - Ready to merge
   - name: add label on conflicts
     conditions:
       - conflict


### PR DESCRIPTION
This change has been made by @inkbeard from Mergify config editor.

Add 'hold merge' label until dependabot PRs are open to test.