### PR TITLE
[INK-25] Split test/lint action and updated mergify rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run lint and unit tests
-        run: pnpm turbo lint test
+      - name: Run unit tests
+        run: pnpm turbo test
+
+      - name: Run lint
+        run: pnpm turbo lint

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,24 +1,39 @@
 shared:
   ci_success: &ci_success
-    - "check-success=CI / Build and Test"
-  queue_merge_conditions: &queue_merge_conditions
+    - "check-success=Build and Test"
+  queue_conditions: &queue_conditions
     - -label=Hold merge
     - -label=Addressing issues
     - -draft
+    - -conflict
     - or :
       - "#approved-reviews-by>=1"
       - label=Ready to merge
 
-
 queue_rules:
   - name: default
-    batch_size: 3
-    conditions:
-      - and: *queue_merge_conditions
+    queue_conditions:
+      - and: *queue_conditions
+      - author!=dependabot[bot]
+    merge_conditions:
+      - and: *queue_conditions
+      - and: *ci_success
+  - name: dep-update
+    batch_size: 10
+    # Wait for up to 30 minutes for the batch to fill up
+    batch_max_wait_time: 30 min
+    queue_conditions:
+      - and: *queue_conditions
+      - author=dependabot[bot]
+    merge_conditions:
+      - and: *queue_conditions
+      - and: *ci_success
 
 pull_request_rules:
   - name: Add PR to default merge queue
-    conditions: *queue_merge_conditions
+    conditions:
+      - and: *queue_conditions
+      - author!=dependabot[bot]
     actions:
       queue:
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,18 +1,37 @@
-queue_rules:
-  - name: default
-    conditions: &default_queue_conditions
-      - -label=Hold merge
-      - -label=Addressing issues
+shared:
+  ci_success: &ci_success
+    - "check-success=CI / Build and Test"
+  queue_merge_conditions: &queue_merge_conditions
+    - -label=Hold merge
+    - -label=Addressing issues
+    - -draft
+    - or :
+      - "#approved-reviews-by>=1"
       - label=Ready to merge
 
+
+queue_rules:
+  - name: default
+    batch_size: 3
+    conditions:
+      - and: *queue_merge_conditions
+
 pull_request_rules:
-  - name: Automatic merge on approval
-    conditions: *default_queue_conditions
+  - name: Add PR to default merge queue
+    conditions: *queue_merge_conditions
     actions:
       queue:
         name: default
         allow_merging_configuration_change: true
-  - name: add label on conflicts
+  - name: Automatically approve Dependabot PRs
+    conditions:
+      - author=dependabot[bot]
+      - and: *ci_success
+      - dependabot-update-type=version-update:semver-patch
+    actions:
+      review:
+        type: APPROVE
+  - name: Test for conflicts
     conditions:
       - conflict
     actions:


### PR DESCRIPTION
## Jira
INK-25

## PR Notes
Updated code based on [mergify documentation](https://docs.mergify.com/integrations/dependabot/)

## Dependent PRs
<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## PR Stack
<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
- #1
  - #2
    - #3 :point_left
-->