### PR TITLE
[ink-35] updated dependabot auto approvals on minor version

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,7 +43,9 @@ pull_request_rules:
     conditions:
       - author=dependabot[bot]
       - and: *ci_success
-      - dependabot-update-type=version-update:semver-patch
+      - or:
+        - dependabot-update-type=version-update:semver-minor
+        - dependabot-update-type=version-update:semver-patch
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
## Jira
INK-35

## PR Notes
Updated condition for auto approvals for minor version updates.

## Dependent PRs
<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## PR Stack
<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
- #1
  - #2
    - #3 :point_left
-->