### PR TITLE
cleaned up PR template to comment out extra titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,15 @@
+<!-- depends-on: #42 -->
+<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->
+
 ## Jira
 INK-
 
 ## PR Notes
 <!-- Add any relevant notes here. -->
 
-## Dependent PRs
-<!-- depends-on: #42 -->
-<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->
-
-## PR Stack
 <!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
 <!--
+## PR Stack
 - #1
   - #2
     - #3 :point_left


### PR DESCRIPTION
Change-Id: I8322a0fc8ed13621660ad47165d3d01987035a12

## Jira
INK-

## PR Notes
The PRs had a lot of space taken up by the "Dependent PRs" and "PR Stack" titles for something not being used to often. "Dependent PRs" removed and the commented code was moved to the top. "PR Stack" is now included in the commented out code.

## Dependent PRs
<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## PR Stack
<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
- #1
  - #2
    - #3 :point_left
-->