### PR TITLE
reduced width on light/dark toggle

### DIFF
--- a/.changeset/thirty-points-heal.md
+++ b/.changeset/thirty-points-heal.md
@@ -1,0 +1,5 @@
+---
+"inkbeard": patch
+---
+
+Reduced toggle wrapper by 1px

--- a/apps/inkbeard/src/components/GlobalNavigation.vue
+++ b/apps/inkbeard/src/components/GlobalNavigation.vue
@@ -238,7 +238,7 @@
     position: fixed;
     top: 20px;
     right: 20px;
-    width: 38px;
+    width: 37px;
     height: 22px;
     margin: 0 10px;
     padding: 0;


### PR DESCRIPTION
Change-Id: I0609b0dabbac4f1ac8f702586ed87dabde182b8f

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira


## PR Notes
On further inspection, I noticed the wrapper for the light/dark mode toggle button was 1px too wide. This PR fixes it.

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->