### PR TITLE
[ink-45] ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,41 +4,30 @@ shared:
   queue_conditions: &queue_conditions
     - -label=Hold merge
     - -label=Addressing issues
-    - -draft
     - -conflict
-    - or :
-      - "#approved-reviews-by>=1"
-      - label=Ready to merge
+    - "#approved-reviews-by>=1"
 
 queue_rules:
+  - name: release
+    merge_conditions:
+      - head=changeset-release/main
+      - "#approved-reviews-by>=1"
   - name: default
     batch_size: 3
     speculative_checks: 3
     queue_conditions:
+      - and: *ci_success
       - and: *queue_conditions
       - author!=dependabot[bot]
-    merge_conditions:
-      - and: *queue_conditions
-      - and: *ci_success
   - name: dep-update
     batch_size: 10
     batch_max_wait_time: 30 min
     queue_conditions:
+      - and: *ci_success
       - and: *queue_conditions
       - author=dependabot[bot]
-    merge_conditions:
-      - and: *queue_conditions
-      - and: *ci_success
 
 pull_request_rules:
-  - name: Add PR to default merge queue
-    conditions:
-      - and: *queue_conditions
-      - author!=dependabot[bot]
-    actions:
-      queue:
-        name: default
-        allow_merging_configuration_change: true
   - name: Automatically approve Dependabot PRs
     conditions:
       - author=dependabot[bot]
@@ -46,6 +35,12 @@ pull_request_rules:
       - or:
         - dependabot-update-type=version-update:semver-minor
         - dependabot-update-type=version-update:semver-patch
+    actions:
+      review:
+        type: APPROVE
+  - name: Add bot approval for PRs ready to merge
+    conditions:
+      - label=Ready to merge
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
This change has been made by @inkbeard from Mergify config editor.

**PR Notes**
1. A new "release" queue was added that just checks for a single approval on the Changelog PR. CI is no longer required to run.
2. "drafts" are only for organizations so the draft mode queue condition was removed. 
3. A new PR request rule was added to approve the PR if the "Ready to merge" label has been added. This is so the repo can require one approval before merging into `main`.
4. Removed the "Add PR to default merge queue" PR rule since the "queue_conditions" is met in the `default` "queue_rules"
5. According to https://docs.mergify.com/merge-queue/setup/#configuring-the-merge-queue-rules, we don't need to repeat the "merge_conditions" if they are in the "queue_conditions", so the "merge_conditions" were removed



