### PR TITLE
removed server.https

### DIFF
--- a/.changeset/big-games-approve.md
+++ b/.changeset/big-games-approve.md
@@ -1,0 +1,5 @@
+---
+"inkbeard": minor
+---
+
+removed 'https' from vite server option

--- a/apps/inkbeard/vite.config.ts
+++ b/apps/inkbeard/vite.config.ts
@@ -15,7 +15,4 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
-  server: {
-    https: true,
-  },
 });


### PR DESCRIPTION
Change-Id: I14564142ada057ba0b8c29c888016cb6db295985

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira


## PR Notes
The https.server isn't required since the basicSsl plugin handles it.

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->