### PR TITLE
wrap examples navigation in feature flag

### DIFF
--- a/.changeset/tricky-hairs-wash.md
+++ b/.changeset/tricky-hairs-wash.md
@@ -1,0 +1,5 @@
+---
+"inkbeard": minor
+---
+
+- Wrapped the examples navigation in a feature flag.

--- a/apps/inkbeard/src/components/GlobalNavigation.vue
+++ b/apps/inkbeard/src/components/GlobalNavigation.vue
@@ -2,6 +2,7 @@
   import { RouterLink, useRouter } from 'vue-router';
   import { ref, watch, onBeforeMount } from 'vue';
   import AppIcon from '@/components/AppIcon.vue';
+  import { useFeatureFlagStore } from '@/stores/featureFlags';
 
   const darkMode = ref(false);
   const isActive = ref(false);
@@ -39,17 +40,19 @@
               inkbeard
             </RouterLink>
           </li>
-          <li
-            v-for="({ name, meta: { title } }) in projects"
-            :key="title"
-          >
-            <RouterLink
-              :to="{ name }"
-              @click="isActive = false"
+          <template v-if="useFeatureFlagStore().flags.examples.enabled">
+            <li
+              v-for="({ name }) in projects"
+              :key="name"
             >
-              {{ title }}
-            </RouterLink>
-          </li>
+              <RouterLink
+                :to="{ name }"
+                @click="isActive = false"
+              >
+                {{ name }}
+              </RouterLink>
+            </li>
+          </template>
         </ul>
         <ul class="external-links">
           <li>

--- a/apps/inkbeard/src/main.ts
+++ b/apps/inkbeard/src/main.ts
@@ -22,7 +22,9 @@ flagsmith.init({
     const featureFlagStore = useFeatureFlagStore();
     featureFlagStore.flags = {
       ...featureFlagStore.flags,
-      examples: flagsmith.hasFeature('examples'),
+      // All feature flags will be set as an object with with `enabled`, `id`, and `value` properties
+      // with the name of the feature flag as the key.
+      ...flagsmith.getAllFlags(),
     };
   },
 });

--- a/apps/inkbeard/src/stores/featureFlags.ts
+++ b/apps/inkbeard/src/stores/featureFlags.ts
@@ -2,5 +2,9 @@ import { ref } from 'vue';
 import { defineStore } from 'pinia';
 
 export const useFeatureFlagStore = defineStore('featureFlags', () => (
-  { flags: ref({}) }
+  {
+    flags: ref({
+      examples: { enabled: false },
+    }),
+  }
 ));


### PR DESCRIPTION
Change-Id: I92fd06a3a76e5da4e4bb1fd123aa9460c3e3dcd8

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira
INK-

## PR Notes
- Wrapped the examples navigation in the "examples" feature flag value
- Updated the feature flag store to include the full object from flagsmith.

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->