### PR TITLE
[ink-48] added expense category rendering

### DIFF
--- a/.changeset/giant-carrots-glow.md
+++ b/.changeset/giant-carrots-glow.md
@@ -1,0 +1,5 @@
+---
+"@inkbeard/budget-it": minor
+---
+
+Added category expense rendering

--- a/packages/budget-it/src/App.vue
+++ b/packages/budget-it/src/App.vue
@@ -22,5 +22,3 @@
   </main>
 </template>
 
-<style scoped>
-</style>

--- a/packages/budget-it/src/App.vue
+++ b/packages/budget-it/src/App.vue
@@ -1,9 +1,26 @@
 <script setup lang="ts">
-  //
+  import ExportCategory from '@/components/ExpenseCategory.vue';
+
+  const categories = [
+    'Entertainment',
+    'Food',
+    'Housing',
+    'Transportation',
+    'Utilities',
+    'Clothing',
+    'Medical',
+  ];
 </script>
 
 <template>
   <main>
-    hello
+    <ExportCategory
+      v-for="category in categories"
+      :key="category"
+      :category="category"
+    />
   </main>
 </template>
+
+<style scoped>
+</style>

--- a/packages/budget-it/src/components/ExpenseCategory.vue
+++ b/packages/budget-it/src/components/ExpenseCategory.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+  import { ref } from 'vue';
+
+  defineProps<{
+    category: string;
+  }>();
+
+  const isOpen = ref(false);
+</script>
+
+<template>
+  <div
+    class="category-section"
+    :class="{ 'is-open': isOpen }"
+  >
+    <div class="category-title">
+      <span>{{ category }}</span>
+      <button
+        type="button"
+        @click="isOpen = !isOpen"
+      >
+        {{ isOpen ? '-' : '+' }}
+      </button>
+    </div>
+    <div
+      v-if="isOpen"
+      class="category-content"
+    >
+      <p>Expenses go here</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.category-section {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.category-title,
+.category-content {
+  padding: 1rem;
+}
+
+.category-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #ccc;
+}
+
+button {
+  width: 36px;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-size: 30px;
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
Change-Id: I20c6cf025103dd08a8f0e60b9d973eda2987dd7c

Depends-On: #109 

**PR Notes**
This is the first pass at ink-48. It's very much bare bones styled while designs are being made. Some expense categories should be rendered out with a collapsed/expanded state.