### PR TITLE
[ink-49] add ability to add new category

### DIFF
--- a/.changeset/itchy-spies-walk.md
+++ b/.changeset/itchy-spies-walk.md
@@ -1,0 +1,5 @@
+---
+"@inkbeard/budget-it": minor
+---
+
+Added ability to add new categories

--- a/packages/budget-it/src/App.vue
+++ b/packages/budget-it/src/App.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+  import { ref } from 'vue';
+  import AddCategory from '@/components/AddCategory.vue';
   import ExportCategory from '@/components/ExpenseCategory.vue';
 
-  const categories = [
+  const categories = ref([
     'Entertainment',
     'Food',
     'Housing',
@@ -9,11 +11,12 @@
     'Utilities',
     'Clothing',
     'Medical',
-  ];
+  ]);
 </script>
 
 <template>
   <main>
+    <AddCategory @add-category="(value:string) => categories.unshift(value)" />
     <ExportCategory
       v-for="category in categories"
       :key="category"

--- a/packages/budget-it/src/components/AddCategory.vue
+++ b/packages/budget-it/src/components/AddCategory.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+  import { ref } from 'vue';
+
+  const emit = defineEmits(['addCategory']);
+  const categoryName = ref('');
+  const isActive = ref(false);
+
+  function cancelEdit() {
+    categoryName.value = '';
+    isActive.value = false;
+  }
+  function addCategory() {
+    if (!categoryName.value) return;
+
+    emit('addCategory', categoryName.value);
+    cancelEdit();
+  }
+</script>
+
+<template>
+  <div class="add-category-container">
+    <div
+      v-if="!isActive"
+      class="button-group"
+    >
+      <button
+        type="button"
+        @click="isActive = true"
+      >
+        Add category
+      </button>
+    </div>
+    <div v-else>
+      <label for="add-category">
+        Category Name:
+      </label>
+      <input
+        id="add-category"
+        v-model="categoryName"
+        type="text"
+        @keydown.enter="addCategory"
+      />
+      <div class="button-group">
+        <button type="button" @click="cancelEdit">
+          Cancel
+        </button>
+        <button
+          :disabled="!categoryName"
+          type="button"
+          @click="addCategory"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.add-category-container {
+  padding: 1rem;
+}
+
+.button-group {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+
+input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+button {
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
Change-Id: Icf27bcedbd00272db269818ab79a1645bf5211cf

Depends-On: #110

**PR Notes**
- This is the first pass at ink-49. It's very much bare bones styled while designs are being made.
- The user should be able to add a new category, along with cancelling adding the new category. 
- The submit button is disabled if the input is empty.
- Hitting the "enter" key should add the new category as well.