### PR TITLE
updated ExpenseInfo interface's ID to be optional

### DIFF
--- a/.changeset/short-buses-sparkle.md
+++ b/.changeset/short-buses-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@inkbeard/budget-it": minor
+---
+
+Updated id to be optional on the ExpenseInfo interface

--- a/packages/budget-it/src/components/ExpenseItem.vue
+++ b/packages/budget-it/src/components/ExpenseItem.vue
@@ -6,8 +6,16 @@
   const props = defineProps<{
     expense: ExpenseInfo;
   }>();
-
   const expenseAmount = ref(props.expense.amount);
+  const updateExpenseAmount = () => {
+    const { expenseList } = useExpensesStore();
+    const { id } = props.expense;
+
+    if (id) {
+      expenseList[id].amount = expenseAmount.value;
+    }
+  };
+
 </script>
 
 <template>
@@ -19,7 +27,7 @@
       :id="`${expense.categoryId}-${expense.name}`"
       v-model="expenseAmount"
       type="number"
-      @blur="useExpensesStore().expenseList[props.expense.id].amount = expenseAmount"
+      @blur="updateExpenseAmount"
     >
   </form>
 </template>

--- a/packages/budget-it/src/stores/expenses.ts
+++ b/packages/budget-it/src/stores/expenses.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia';
 export interface ExpenseInfo {
   amount: number // Amount of the expense
   categoryId: number // Unique identifier for the category the expense belongs to
-  id: number // Unique identifier for the expense
+  id?: number // Unique identifier for the expense
   name: string // Name of the expense
   order: number // Order of the expense in the list
   source: null | string // Source of the expense (e.g. "Credit Card", "Debit Card", "Cash")


### PR DESCRIPTION
Change-Id: Ia88108674d2324006ab78a1fa4e60ab804af2ec7

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira
INK-

## PR Notes
<!-- Add any relevant notes here. -->

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->