### PR TITLE
[ink-55] added expense source option to the expense item

### DIFF
--- a/.changeset/honest-keys-pull.md
+++ b/.changeset/honest-keys-pull.md
@@ -1,0 +1,6 @@
+---
+"@inkbeard/budget-it": minor
+---
+
+- Added getter for getting an alphabatized list of sources
+- Added dropdown for the sources in the expense items

--- a/packages/budget-it/src/components/ExpenseItem.vue
+++ b/packages/budget-it/src/components/ExpenseItem.vue
@@ -1,14 +1,25 @@
 <script setup lang="ts">
-  import { ref } from 'vue';
+  import { computed, ref } from 'vue';
   import type { ExpenseInfo } from '@/stores/expenses';
   import { useExpensesStore } from '@/stores/expenses';
+  import { useSourcesStore } from '@/stores/sources';
 
   const props = defineProps<{
     expense: ExpenseInfo;
   }>();
+  const { expenseList } = useExpensesStore();
   const expenseAmount = ref(props.expense.amount);
+  const expenseSourceId = computed({
+    get: () => props.expense.sourceId,
+    set: (value: number) => {
+      const { id } = props.expense;
+
+      if (id) {
+        expenseList[id].sourceId = value;
+      }
+    },
+  });
   const updateExpenseAmount = () => {
-    const { expenseList } = useExpensesStore();
     const { id } = props.expense;
 
     if (id) {
@@ -34,6 +45,15 @@
       type="number"
       @blur="updateExpenseAmount"
     >
+    <select v-model="expenseSourceId">
+      <option
+        v-for="({ id, source }) in useSourcesStore().alphabaticSourceList"
+        :key="id"
+        :value="id"
+      >
+        {{ source }}
+      </option>
+    </select>
   </form>
 </template>
 

--- a/packages/budget-it/src/stores/__tests__/expenses.spec.ts
+++ b/packages/budget-it/src/stores/__tests__/expenses.spec.ts
@@ -8,7 +8,7 @@ describe('expenses Store', () => {
     categoryId: 1,
     name: 'Test',
     order: 0,
-    source: null,
+    sourceId: 1,
   };
 
   beforeEach(() => {

--- a/packages/budget-it/src/stores/__tests__/sources.spec.ts
+++ b/packages/budget-it/src/stores/__tests__/sources.spec.ts
@@ -17,6 +17,17 @@ describe('sources Store', () => {
     store.sourceList = { ...sourceList };
   });
 
+  describe('alphabaticSourceList', () => {
+    it('should return an alphabatize list of sources and their IDs', () => {
+      expect(store.alphabaticSourceList)
+        .toEqual([
+          { source: 'Checking Account', id: 3 },
+          { source: 'Debit Card', id: 1 },
+          { source: 'Savings Account', id: 4 },
+        ]);
+    });
+  });
+
   describe('addSource', () => {
     it('should assign the next highest number as the ID ', () => {
       store.addSource('Test Source');

--- a/packages/budget-it/src/stores/expenses.ts
+++ b/packages/budget-it/src/stores/expenses.ts
@@ -7,7 +7,7 @@ export interface ExpenseInfo {
   id?: number // Unique identifier for the expense
   name: string // Name of the expense
   order: number // Order of the expense in the list
-  source: null | string // Source of the expense (e.g. "Credit Card", "Debit Card", "Cash")
+  sourceId: number // Source Id of the expense that is mapped from the sources store
 }
 
 interface ExpenseList {
@@ -20,52 +20,46 @@ export const useExpensesStore = defineStore('expenses', {
       1: {
         amount: 2,
         categoryId: 1,
-        id: 1,
         name: 'Netflix',
         order: 0,
-        source: null,
+        sourceId: 1,
       },
       2: {
         amount: 2,
         categoryId: 2,
-        id: 2,
         name: 'HBFC',
         order: 0,
-        source: null,
+        sourceId: 5,
       },
       3: {
         amount: 1000,
         categoryId: 3,
         description: 'Started with Guaranteed Rate and then refinanced with Better.com.',
-        id: 3,
         name: 'Mortgage',
         order: 0,
-        source: null,
+        sourceId: 3,
       },
       4: {
         amount: 30,
         categoryId: 4,
-        id: 4,
         name: 'Gas',
         order: 0,
-        source: null,
+        sourceId: 1,
       },
       5: {
         amount: 50,
         categoryId: 5,
-        id: 5,
         name: 'Target',
         order: 0,
-        source: null,
+        sourceId: 1,
       },
       7: {
         amount: 2260,
         categoryId: 7,
         description: 'Monthly premium for family of 4.',
-        id: 7,
         name: 'BCBS',
         order: 0,
-        source: null,
+        sourceId: 3,
       },
     } as ExpenseList,
   }),

--- a/packages/budget-it/src/stores/sources.ts
+++ b/packages/budget-it/src/stores/sources.ts
@@ -4,12 +4,23 @@ export const useSourcesStore = defineStore('sources', {
   state: () => ({
     sourceList: {
       1: 'Credit Card',
-      2: 'Debit Card',
       3: 'Checking Account',
       4: 'Savings Account',
       5: 'Cash',
     } as Record<number, string>,
   }),
+  getters: {
+    /**
+     * Get an alphabatize list of sources and their IDs.
+     */
+    alphabaticSourceList(): { source: string, id: number }[] {
+      const sourceList = Object.entries(this.sourceList).map(([id, source]) => (
+        { source, id: +id }
+      ));
+
+      return sourceList.sort((a, b) => a.source.toLowerCase().localeCompare(b.source.toLowerCase()));
+    },
+  },
   actions: {
     /**
      * Add a new source to the current list of sources with the ID + 1 of the highest ID so far.


### PR DESCRIPTION
Change-Id: I5191e5bd6bbbac490aa7317bbe1038fe56d20bdc

Depends-On: #138


<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira
ink-55

## PR Notes
Added a `<select />` where the model is the expense's `sourceId`. 

## PR Stack
- #138 
  - #139 :point_left: