### PR TITLE
[ink-62] Added default source logic

### DIFF
--- a/.changeset/four-queens-learn.md
+++ b/.changeset/four-queens-learn.md
@@ -1,0 +1,10 @@
+---
+"@inkbeard/budget-it": minor
+---
+
+- Added default logic to the addSource action
+- Removed emits in the SourceListing
+- Added isEditing model to SourceListing for communication to the parent and self
+- Added default checkbox new source logic
+- Added icon to quickly make existing sources the default
+- Removed store logic in the SourceEditor

--- a/packages/budget-it/README.md
+++ b/packages/budget-it/README.md
@@ -30,25 +30,25 @@ pnpm install
 ### Compile and Hot-Reload for Development
 
 ```sh
-pnpm dev
+pnpm dev --filter budget-it
 ```
 
 ### Type-Check, Compile and Minify for Production
 
 ```sh
-pnpm build
+pnpm build --filter budget-it
 ```
 
 ### Run Unit Tests with [Vitest](https://vitest.dev/)
 
 ```sh
-pnpm test:unit
+pnpm test:unit --filter budget-it
 ```
 
 ### Run End-to-End Tests with [Cypress](https://www.cypress.io/)
 
 ```sh
-pnpm test:e2e:dev
+pnpm test:e2e:dev --filter budget-it
 ```
 
 This runs the end-to-end tests against the Vite development server.
@@ -57,12 +57,12 @@ It is much faster than the production build.
 But it's still recommended to test the production build with `test:e2e` before deploying (e.g. in CI environments):
 
 ```sh
-pnpm build
-pnpm test:e2e
+pnpm build --filter budget-it
+pnpm test:e2e --filter budget-it
 ```
 
 ### Lint with [ESLint](https://eslint.org/)
 
 ```sh
-pnpm lint
+pnpm lint --filter budget-it
 ```

--- a/packages/budget-it/src/components/SourceListing.vue
+++ b/packages/budget-it/src/components/SourceListing.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-  import { computed, ref, nextTick } from 'vue';
+  import { computed, ref } from 'vue';
   import { useSourcesStore } from '@/stores/sources';
 
   const props = defineProps<{
     sourceId?: number,
   }>();
-  const emit = defineEmits<{
-    (e: 'addSource', sourceName: string): void
-    (e: 'cancelAddSource'): void
-    (e: 'updateSource', sourceName: string): void
-  }>();
-
-  const { sourceList } = useSourcesStore();
-  const isEditing = ref(false);
+  const {
+    addSource,
+    deleteSource,
+    sourceList,
+    sourcesWithExpenses,
+  } = useSourcesStore();
+  const isDefault = ref(false);
+  const isEditing = defineModel('isEditing', { type: Boolean });
   const sourceName = props.sourceId
     ? ref(sourceList[props.sourceId])
     : ref('');
@@ -21,7 +21,7 @@
    */
   const sourceIsDisabled = computed(() => (
     !sourceName.value
-    || Object.values(useSourcesStore().sourceList).some((source) => (
+    || Object.values(sourceList).some((source) => (
       source.toLowerCase() === sourceName.value.toLowerCase()
     ))
   ));
@@ -30,31 +30,28 @@
    */
   const cancelEdit = () => {
     isEditing.value = false;
-
     sourceName.value = props.sourceId
       ? sourceList[props.sourceId]
       : '';
-
-    emit('cancelAddSource');
   };
   /**
-   * Add a new source if it doesn't exist already or edit an existing source.
+   * Add a new source if it doesn't exist already or edit an existing source, then cancel the source editing state.
    */
-  const updateSourceName = async () => {
+  const onSourceSave = () => {
     if (sourceIsDisabled.value) {
       return;
     }
 
     if (props.sourceId) {
-      emit('updateSource', sourceName.value);
-
-      await nextTick();
-
-      isEditing.value = false;
-      return;
+      sourceList[props.sourceId] = sourceName.value;
+    } else {
+      addSource({
+        isDefault: isDefault.value,
+        sourceName: sourceName.value,
+      });
     }
 
-    emit('addSource', sourceName.value);
+    isEditing.value = false;
   };
 </script>
 
@@ -62,36 +59,63 @@
   <li>
     <form
       v-if="isEditing || !sourceId"
-      @submit.prevent="updateSourceName"
+      @submit.prevent="onSourceSave"
     >
-      <input
-        v-model="sourceName"
-        aria-label="New source"
-        data-test="new source"
-        type="text"
-      />
-      <div class="btn-group">
-        <button
-          aria-label="Cancel new source"
-          data-test="cancel new source"
-          type="button"
-          @click="cancelEdit"
-        >
-          <i class="fa-solid fa-xmark fa-lg" />
-        </button>
-        <button
-          aria-label="Save source"
-          data-test="save source"
-          :disabled="sourceIsDisabled"
-          type="submit"
-        >
-          <i class="fa-solid fa-check fa-lg" />
-        </button>
+      <div>
+        <input
+          v-model="sourceName"
+          aria-label="New source"
+          data-test="new source"
+          type="text"
+        />
+        <div class="btn-group">
+          <button
+            aria-label="Cancel new source"
+            data-test="cancel new source"
+            type="button"
+            @click="cancelEdit"
+          >
+            <i class="fa-solid fa-xmark fa-lg" />
+          </button>
+          <button
+            aria-label="Save source"
+            data-test="save source"
+            :disabled="sourceIsDisabled"
+            type="submit"
+          >
+            <i class="fa-solid fa-check fa-lg" />
+          </button>
+        </div>
       </div>
+      <label
+        v-if="!sourceId"
+        :for="`default-${sourceId || 'new'}`"
+      >
+        <input
+          :id="`default-${sourceId || 'new'}`"
+          v-model="isDefault"
+          type="checkbox"
+        />
+        Set source as default
+      </label>
     </form>
     <template v-else>
       {{ sourceName }}
       <div class="btn-group">
+        <button
+          aria-label="Set default source"
+          data-test="set default"
+          title="Set as default source"
+          type="button"
+          @click="useSourcesStore().defaultSourceId = sourceId"
+        >
+          <i
+            class="fa-lg"
+            :class="useSourcesStore().defaultSourceId === sourceId
+              ? 'fa-duotone fa-star'
+              : 'fa-regular fa-star'"
+          />
+        </button>
         <button
           aria-label="Edit source"
           data-test="edit source"
@@ -103,9 +127,9 @@
         <button
           aria-label="Delete source"
           data-test="delete source"
-          :disabled="useSourcesStore().sourcesWithExpenses[sourceId]?.length"
+          :disabled="sourcesWithExpenses[sourceId]?.length"
           type="button"
-          @click="useSourcesStore().deleteSource(sourceId)"
+          @click="deleteSource(sourceId)"
         >
           <i class="fa-duotone fa-trash-can fa-lg" />
         </button>
@@ -117,9 +141,15 @@
 <style scoped>
 form {
   display: flex;
+  flex-direction: column;
   flex: 1;
   gap: .5rem;
   justify-content: space-between;
+
+  > div {
+    display: flex;;
+    flex-direction: row;
+  }
 }
 
 input {

--- a/packages/budget-it/src/components/SourcesEditor.vue
+++ b/packages/budget-it/src/components/SourcesEditor.vue
@@ -1,19 +1,9 @@
 <script setup lang="ts">
-  import { ref, nextTick } from 'vue';
+  import { ref } from 'vue';
   import { useSourcesStore } from '@/stores/sources';
   import SourceListing from '@/components/SourceListing.vue';
 
   const isAdding = ref(false);
-  /**
-   * Add a new source if it doesn't exist already.
-   */
-  const addSource = async (value: string) => {
-    useSourcesStore().addSource(value);
-
-    await nextTick();
-
-    isAdding.value = false;
-  };
 </script>
 
 <template>
@@ -32,14 +22,12 @@
   <ul>
     <SourceListing
       v-if="isAdding"
-      @add-source="addSource"
-      @cancel-add-source="isAdding = false"
+      v-model:is-editing="isAdding"
     />
     <SourceListing
       v-for="({ id }) in useSourcesStore().alphabaticSourceList"
       :key="id"
       :source-id="id"
-      @update-source="useSourcesStore().sourceList[id] = $event"
     />
   </ul>
 </template>

--- a/packages/budget-it/src/stores/__tests__/sources.spec.ts
+++ b/packages/budget-it/src/stores/__tests__/sources.spec.ts
@@ -14,6 +14,7 @@ describe('sources Store', () => {
     setActivePinia(createPinia());
 
     store = useSourcesStore();
+    store.defaultSourceId = 4;
     store.sourceList = { ...sourceList };
   });
 
@@ -29,14 +30,24 @@ describe('sources Store', () => {
   });
 
   describe('addSource', () => {
-    it('should assign the next highest number as the ID ', () => {
-      store.addSource('Test Source');
+    it('should assign the next highest number as the ID', () => {
+      store.addSource({ sourceName: 'Test Source' });
 
       expect(store.sourceList)
         .toEqual({
           ...sourceList,
           5: 'Test Source',
         });
+    });
+
+    it('should assign default source ID if isDefault', () => {
+      store.addSource({
+        isDefault: true,
+        sourceName: 'Test Source',
+      });
+
+      expect(store.defaultSourceId)
+        .toBe(5);
     });
   });
 

--- a/packages/budget-it/src/stores/sources.ts
+++ b/packages/budget-it/src/stores/sources.ts
@@ -3,6 +3,7 @@ import { useExpensesStore } from './expenses';
 
 export const useSourcesStore = defineStore('sources', {
   state: () => ({
+    defaultSourceId: 4,
     sourceList: {
       1: 'Credit Card',
       3: 'Checking Account',
@@ -41,10 +42,18 @@ export const useSourcesStore = defineStore('sources', {
     /**
      * Add a new source to the current list of sources with the ID + 1 of the highest ID so far.
      */
-    addSource(sourceName: string) {
-      const sourceIds = Object.keys(this.sourceList).map(Number);
+    addSource(
+      { sourceName, isDefault }: { sourceName: string, isDefault?: boolean },
+    ): number {
+      const newSourceId = Math.max(...Object.keys(this.sourceList).map(Number)) + 1;
 
-      this.sourceList[Math.max(...sourceIds) + 1] = sourceName;
+      this.sourceList[newSourceId] = sourceName;
+
+      if (isDefault) {
+        this.defaultSourceId = newSourceId;
+      }
+
+      return newSourceId;
     },
     /**
      * Delete a source from the current list of sources.


### PR DESCRIPTION
Change-Id: Idf01d4ee53b8ee0a183f084f373474246718a6e0

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira
INK-62

## PR Notes
- I've moved quite a bit of logic around here to make things communicate with the store more directly instead of through emits. This will allow the **SourceListing** component to be used anywhere outside of the **SourceEditor** component.
- I've also updated the README for this to be clearer with the turbo repo scripts.

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->