### PR TITLE
Added mergify partitions and label-maker github action

### DIFF
--- a/.github/workflows/label-maker.yml
+++ b/.github/workflows/label-maker.yml
@@ -1,0 +1,43 @@
+name: Create Label
+
+on:
+  workflow_dispatch:
+    inputs:
+      project_name:
+        description: 'The project name to use for the label'
+        required: true
+        default: 'default'
+        type: string
+
+jobs:
+  create-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create label
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { repo: { owner, repo } } = context;
+            const name = 'new-label';
+            const color = 'f1c40f';
+            const description = 'This is a new label';
+
+            try {
+              console.log(github.inputs.project_name)
+              console.log(github.rest.issues)
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name,
+                color,
+                description,
+              });
+              console.log(`Label "${name}" created.`);
+            } catch (error) {
+              if (error.status === 422) {
+                console.log(`Label "${name}" already exists.`);
+              } else {
+                console.error(error);
+              }
+            }

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -117,6 +117,16 @@ pull_request_rules:
             - workflow: label-maker.yaml
               inputs:
                 project_name: test
+  - name: Add default project label
+    conditions:
+      - partition-name=default
+    actions:
+      github_actions:
+        workflow:
+          dispatch:
+            - workflow: label-maker.yaml
+              inputs:
+                project_name: default
   - name: Add PR stack label for stacked PRs created by mergify
     conditions:
       - head~=mergify_cli/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,28 @@
+partition_rules:
+  - name: default
+    fallback_partition: true
+
+  - name: inkbeard site
+    conditions:
+      - files~=^apps/inkbeard/
+
+  - name: example library
+    conditions:
+      - files~=^apps/ui-library/
+
+  - name: budget it
+    conditions:
+      - files~=^packages/budget-it/
+
+  - name: general ui
+    conditions:
+      - files~=^packages/ui-theme/
+      - files~=^packages/ui-vue/
+      - files~=^packages/ui/
+      - files~=^packages/eslint-config/
+      - files~=^packages/stylelint-config/
+      - files~=^packages/typescript-config/
+
 shared:
   ci_success: &ci_success
     - "check-success=Build and Test"
@@ -82,6 +107,16 @@ pull_request_rules:
         toggle:
           - conflict
   # PR label rules
+  - name: Add appropriate project labels
+    conditions:
+      - partition-name!=default
+    actions:
+      github_actions:
+        workflow:
+          dispatch:
+            - workflow: label-maker.yaml
+              inputs:
+                project_name: test
   - name: Add PR stack label for stacked PRs created by mergify
     conditions:
       - head~=mergify_cli/


### PR DESCRIPTION
Change-Id: Id3cecff3a1a4aabe4a19303513d6f1a81fc290f2

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Reading material
- [documentation on github action inputs context](https://docs.github.com/en/actions/learn-github-actions/contexts#inputs-context)
- [github api documentation](https://cli.github.com/manual/gh_api)
- [mergify documentation on dispatching workflows](https://docs.mergify.com/workflow/actions/github_actions/)

## PR Notes
This is a first round of playing with [mergify's partitions](https://docs.mergify.com/merge-queue/partitions/) along with an action that will automatically create a new label. When there are multiple teams, a label can be added and/or appropriate teams could be requested to review. 

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->