### PR TITLE
moved themes into ui-vue

### DIFF
--- a/.changeset/beige-bottles-notice.md
+++ b/.changeset/beige-bottles-notice.md
@@ -1,0 +1,10 @@
+---
+"@inkbeard/budget-it": minor
+"@inkbeard/ui-theme": minor
+"ui-library": minor
+"@inkbeard/ui-vue": minor
+"inkbeard": minor
+---
+
+- Added ui-theme to ui-vue component package.
+- Replaced old ui-theme with ui-vue component package.

--- a/apps/inkbeard/package.json
+++ b/apps/inkbeard/package.json
@@ -16,7 +16,7 @@
     "stylelint": "stylelint \"**/*.{css,scss,vue}\""
   },
   "dependencies": {
-    "@inkbeard/ui-theme": "workspace:*",
+    "@inkbeard/ui-vue": "workspace:*",
     "@vitejs/plugin-basic-ssl": "^1.1.0",
     "flagsmith": "^3.22.0",
     "pinia": "^2.1.7",
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@inkbeard/eslint-config": "workspace:*",
     "@inkbeard/stylelint-config": "workspace:*",
-    "@inkbeard/ui-vue": "workspace:*",
     "@tsconfig/node18": "^18.2.2",
     "@types/jsdom": "^21.1.6",
     "@types/node": "^17.0.12",

--- a/apps/inkbeard/src/assets/main.css
+++ b/apps/inkbeard/src/assets/main.css
@@ -1,3 +1,1 @@
-@import url('@inkbeard/ui-theme/base.css');
-@import url('@inkbeard/ui-theme/theme.css');
-@import url('@inkbeard/ui-theme/typography.css');
+@import url('@inkbeard/ui-vue/main.css');

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -10,7 +10,6 @@
     "init-msw": "msw init public/"
   },
   "dependencies": {
-    "@inkbeard/ui-theme": "workspace:*",
     "@inkbeard/ui-vue": "workspace:*",
     "pinia": "^2.1.7",
     "vue": "^3.4.18"

--- a/apps/ui-library/src/assets/global.css
+++ b/apps/ui-library/src/assets/global.css
@@ -1,3 +1,1 @@
-@import url('@inkbeard/ui-theme/base.css');
-@import url('@inkbeard/ui-theme/theme.css');
-@import url('@inkbeard/ui-theme/typography.css');
+@import url('@inkbeard/ui-vue/main.css');

--- a/packages/budget-it/package.json
+++ b/packages/budget-it/package.json
@@ -11,12 +11,12 @@
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'",
     "build-only": "vite build",
     "type-check": "vue-tsc --build --force",
-    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
+    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
     "lint:fix": "pnpm lint --fix",
     "stylelint": "stylelint \"**/*.{css,scss,vue}\""
   },
   "dependencies": {
-    "modern-normalize": "^2.0.0",
+    "@inkbeard/ui-vue": "workspace:*",
     "pinia": "^2.1.7",
     "vue": "^3.4.18"
   },

--- a/packages/budget-it/src/assets/main.css
+++ b/packages/budget-it/src/assets/main.css
@@ -1,6 +1,4 @@
-@import url('@inkbeard/ui-theme/base.css');
-@import url('@inkbeard/ui-theme/theme.css');
-@import url('@inkbeard/ui-theme/typography.css');
+@import url('@inkbeard/ui-vue/main.css');
 
 #app {
   max-width: 1280px;

--- a/packages/ui-theme/assets/base.css
+++ b/packages/ui-theme/assets/base.css
@@ -1,9 +1,4 @@
-@import 'modern-normalize/modern-normalize.css';
-
-* {
-  margin: 0;
-  font-weight: normal;
-}
+@import url('modern-normalize/modern-normalize.css') layer(app-level);
 
 body {
   min-height: 100vh;

--- a/packages/ui-vue/package.json
+++ b/packages/ui-vue/package.json
@@ -3,8 +3,14 @@
   "version": "0.0.0",
   "main": "./index.ts",
   "module": "./index.ts",
+  "files": [
+    "assets"
+  ],
   "exports": {
-    ".": "./index.ts"
+    ".": "./index.ts",
+    "./*.css": {
+      "import": "./src/assets/*.css"
+    }
   },
   "scripts": {
     "test:unit": "vitest run",
@@ -20,6 +26,7 @@
   "devDependencies": {
     "@inkbeard/eslint-config": "workspace:*",
     "@inkbeard/stylelint-config": "workspace:*",
+    "@inkbeard/ui-theme": "workspace:*",
     "@tsconfig/node18": "^18.2.2",
     "@types/jsdom": "^21.1.6",
     "@types/node": "^17.0.12",

--- a/packages/ui-vue/src/assets/main.css
+++ b/packages/ui-vue/src/assets/main.css
@@ -1,0 +1,4 @@
+@import url('@inkbeard/ui-theme/base.css');
+@import url('@inkbeard/ui-theme/theme.css');
+@import url('@inkbeard/ui-theme/typography.css');
+@import url('primevue/resources/themes/aura-light-green/theme.css');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,9 @@ importers:
 
   apps/inkbeard:
     dependencies:
-      '@inkbeard/ui-theme':
+      '@inkbeard/ui-vue':
         specifier: workspace:*
-        version: link:../../packages/ui-theme
+        version: link:../../packages/ui-vue
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.1.0
         version: 1.1.0(vite@5.0.10)
@@ -100,9 +100,6 @@ importers:
       '@inkbeard/stylelint-config':
         specifier: workspace:*
         version: link:../../packages/stylelint-config
-      '@inkbeard/ui-vue':
-        specifier: workspace:*
-        version: link:../../packages/ui-vue
       '@tsconfig/node18':
         specifier: ^18.2.2
         version: 18.2.2
@@ -151,9 +148,6 @@ importers:
 
   apps/ui-library:
     dependencies:
-      '@inkbeard/ui-theme':
-        specifier: workspace:*
-        version: link:../../packages/ui-theme
       '@inkbeard/ui-vue':
         specifier: workspace:*
         version: link:../../packages/ui-vue
@@ -267,9 +261,9 @@ importers:
 
   packages/budget-it:
     dependencies:
-      modern-normalize:
-        specifier: ^2.0.0
-        version: 2.0.0
+      '@inkbeard/ui-vue':
+        specifier: workspace:*
+        version: link:../ui-vue
       pinia:
         specifier: ^2.1.7
         version: 2.1.7(typescript@5.3.3)(vue@3.4.18)
@@ -445,6 +439,9 @@ importers:
       '@inkbeard/stylelint-config':
         specifier: workspace:*
         version: link:../stylelint-config
+      '@inkbeard/ui-theme':
+        specifier: workspace:*
+        version: link:../ui-theme
       '@tsconfig/node18':
         specifier: ^18.2.2
         version: 18.2.2


### PR DESCRIPTION
Change-Id: I41d437c2f9da5385ad26bb9726174fa7042d2839

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira
INK-

## PR Notes
This is a bit of organization to pinpoint an issue that is happening downstream from this code. The meat of it that the ui-vue package now imports the ui-theme so any application/package that imports the ui-vue package automatically imports the ui-theme.

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->