### PR TITLE
[INK-68] removed `labelDescription` prop from the "amount" input component

### DIFF
--- a/.changeset/orange-chefs-battle.md
+++ b/.changeset/orange-chefs-battle.md
@@ -1,0 +1,5 @@
+---
+"@inkbeard/budget-it": minor
+---
+
+- [INK-68] removed `labelDescription` prop from the "amount" input component

--- a/packages/budget-it/src/components/AddExpense.vue
+++ b/packages/budget-it/src/components/AddExpense.vue
@@ -88,7 +88,6 @@
         currency="USD"
         :input-id="`${categoryId}-${newExpense.name}`"
         label="Amount"
-        :label-description="newExpense.description"
         mode="currency"
       />
       <AppDropdown


### PR DESCRIPTION
Change-Id: I24cbb47b629eeb1e3dd148bcf575487386dfd2a4