### PR TITLE
[ink-71] updated v-model on ExpenseCategory

### DIFF
--- a/.changeset/seven-singers-applaud.md
+++ b/.changeset/seven-singers-applaud.md
@@ -1,0 +1,5 @@
+---
+"@inkbeard/budget-it": minor
+---
+
+- [ink-71] fixed expense category not adding expenses

--- a/.changeset/seven-singers-applaud.md
+++ b/.changeset/seven-singers-applaud.md
@@ -3,3 +3,4 @@
 ---
 
 - [ink-71] fixed expense category not adding expenses
+- Added <BaseExpenseInfo> and extended <ExpenseInfo> to include it

--- a/packages/budget-it/src/components/ExpenseCategory.vue
+++ b/packages/budget-it/src/components/ExpenseCategory.vue
@@ -3,7 +3,6 @@
   import { AppButton } from '@inkbeard/ui-vue';
   import type {
     CategoryInfo,
-    ExpenseInfo,
     ExpenseList,
   } from '../types';
   import ExpenseItem from './ExpenseItem.vue';
@@ -41,33 +40,32 @@
     emits('deleteCategory', props.category.id);
   };
   /**
-   * Get the information for all the expenses for this category.
+   * Get the id and amount for all the expenses for this category.
    */
   const categoryExpenses = computed(() => (
     Object.entries(expenseList).reduce((acc, [id, expense]) => {
       if (expense.categoryId === props.category.id) {
         acc.push({
-          ...expense,
           id: Number(id),
+          amount: expense.amount,
         });
       }
       return acc;
-    }, [] as ({ id: number } & ExpenseInfo)[])
+    }, [] as ({ id: number, amount: number })[])
   ));
   /**
    * Get the total amount of all the expenses for this category.
    */
   const totalExpenses = computed(() => (
-    categoryExpenses.value.reduce((acc, expense) => acc + expense.amount, 0)
+    categoryExpenses.value.reduce((acc, { amount }) => acc + amount, 0)
   ));
   /**
    * Show confirmation when the user has successfully edited an expense name or description.
    */
-  function onEditExpense({ id, name, description }: {
+  function onEditExpense(
     id: number,
-    name: string,
-    description: string
-  }) {
+    { name, description }: { name: string, description: string },
+  ) {
     // eslint-disable-next-line no-console
     console.log('Edited expense:', { id, name, description });
   }
@@ -121,13 +119,13 @@
         </div>
         <template v-if="categoryExpenses.length">
           <ExpenseItem
-            v-for="(expense, index) in categoryExpenses"
-            :id="expense.id"
-            :key="expense.id"
-            v-model:expense="categoryExpenses[index]"
+            v-for="({ id }) in categoryExpenses"
+            :id="id"
+            :key="id"
+            v-model:expense="expenseList[id]"
             class="category-expense"
             data-test="category expense"
-            @edit-expense="onEditExpense"
+            @edit-expense="onEditExpense(id, $event)"
           />
         </template>
         <p v-else>

--- a/packages/budget-it/src/components/ExpenseCategory.vue
+++ b/packages/budget-it/src/components/ExpenseCategory.vue
@@ -2,6 +2,7 @@
   import { computed, inject } from 'vue';
   import { AppButton } from '@inkbeard/ui-vue';
   import type {
+    BaseExpenseInfo,
     CategoryInfo,
     ExpenseList,
   } from '../types';
@@ -64,7 +65,7 @@
    */
   function onEditExpense(
     id: number,
-    { name, description }: { name: string, description: string },
+    { name, description }: BaseExpenseInfo,
   ) {
     // eslint-disable-next-line no-console
     console.log('Edited expense:', { id, name, description });
@@ -125,7 +126,7 @@
             v-model:expense="expenseList[id]"
             class="category-expense"
             data-test="category expense"
-            @edit-expense="onEditExpense(id, $event)"
+            @edit-expense="onEditExpense(id, $event as BaseExpenseInfo)"
           />
         </template>
         <p v-else>

--- a/packages/budget-it/src/components/ExpenseItem.vue
+++ b/packages/budget-it/src/components/ExpenseItem.vue
@@ -15,9 +15,9 @@
      * Emit the edited name and description of the expense item.
      */
     editExpense: [{
-      id: number,
-      name: string,
-      description: string
+      name?: string,
+      description?: string,
+      amount?: number,
     }]
   }>();
 
@@ -41,7 +41,6 @@
     expense.value.description = expenseDescription.value;
     isEditing.value = false;
     emits('editExpense', {
-      id: expense.value.id as number,
       name: editableExpense.value.name,
       description: editableExpense.value.description || '',
     });

--- a/packages/budget-it/src/components/ExpenseItem.vue
+++ b/packages/budget-it/src/components/ExpenseItem.vue
@@ -8,17 +8,13 @@
     Tooltip,
     AppInputText,
   } from '@inkbeard/ui-vue';
-  import type { ExpenseInfo, LabelsAndIds } from '../types';
+  import type { BaseExpenseInfo, ExpenseInfo, LabelsAndIds } from '../types';
 
   const emits = defineEmits<{
     /**
      * Emit the edited name and description of the expense item.
      */
-    editExpense: [{
-      name?: string,
-      description?: string,
-      amount?: number,
-    }]
+    editExpense: [BaseExpenseInfo]
   }>();
 
   const alphabaticSourceList = inject<LabelsAndIds>('alphabaticSourceList', []);
@@ -40,6 +36,7 @@
     expense.value.name = expenseName.value;
     expense.value.description = expenseDescription.value;
     isEditing.value = false;
+
     emits('editExpense', {
       name: editableExpense.value.name,
       description: editableExpense.value.description || '',

--- a/packages/budget-it/src/types.ts
+++ b/packages/budget-it/src/types.ts
@@ -1,7 +1,18 @@
+export interface BaseExpenseInfo {
+  /**
+   * Description of the expense.
+   */
+  description?: string
+  /**
+   * Name of the expense.
+   */
+  name: string
+}
+
 /**
  * General information about a particular expense.
  */
-export interface ExpenseInfo {
+export interface ExpenseInfo extends BaseExpenseInfo {
   /**
    * Amount of the expense.
    */
@@ -11,17 +22,9 @@ export interface ExpenseInfo {
    */
   categoryId: number
   /**
-   * Description of the expense.
-   */
-  description?: string
-  /**
    * Unique identifier for the expense.
    */
   id?: number
-  /**
-   * Name of the expense.
-   */
-  name: string
   /**
    * Order of the expense in the list.
    */


### PR DESCRIPTION
Change-Id: Ie0dd41f0fd2a4c5c126a489f5c735c2ecf7bf207

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira
INK-71

## PR Notes
The **ExpenseItem component** was getting passed the expense object from `categoryExpenses`. While this provided the downward data, since it's a computed property, it wasn't actually changing the `expenseList` data. I updated the `categoryExpenses` to return the ids and the amounts. This way, the v-model for the **ExpenseItem component** will point to `expenseList` data.

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->