### PR TITLE
added conditioning for ci_success

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,12 @@
 shared:
   ci_success: &ci_success
     - "check-success=Build and Test"
-    - "check-success=netlify/dainty-arithmetic-94f385/deploy-preview"
+    - or:
+      - and:
+        - head=main
+        - "check-success=netlify/dainty-arithmetic-94f385/deploy-preview"
+      - and:
+        - head!=main
   queue_conditions: &queue_conditions
     - -label=Hold merge
     - -label=Addressing issues


### PR DESCRIPTION
Change-Id: I6d566408e632e20b46401061c1256d98489e07b1

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira
INK-

## PR Notes
Stacked PRs don't build a preview since netlify only does that for PRs against `main`. This should update it 
1. any stacked PRs _should_ get added to the queue
1. Once an approved PR has been added to the queue, the temp PR (based against `main`) will build/deploy a preview (satisfying the `ci_success` conditions) or updating the PR with `main` will also meet the meet the `ci_success` conditions.

This isn't an ideal process, but I need to look at some devops things as this project scales, and potentially move over from netlify to vercel.

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->