### PR TITLE
added feature: generator label rule when working with the generator

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -128,6 +128,13 @@ pull_request_rules:
       label:
         add:
           - PR stack
+  - name: toggle generator label
+    conditions:
+      - files~=turbo/generators/
+    actions:
+      label:
+        toggle:
+          - "feature: generator"
   # Partition rules
   # Would ideally have this as dynamic, but Mergify doesn't support the `partition-queue-name` attribute at the moment.
   - name: inkbeard partition workflow


### PR DESCRIPTION
Change-Id: Icd3124ff2bd48d979721fb97189696149614fae8

**PR notes**
This adds a label when the PR is updating a generator.