### PR TITLE
added 'feature: generator' label and updated 'pr stack' label to look at base instead of head

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -121,9 +121,9 @@ pull_request_rules:
         toggle:
           - conflict
   # PR label rules
-  - name: Add PR stack label for stacked PRs created by mergify
+  - name: Add PR stack label for stacked PRs
     conditions:
-      - head~=mergify_cli/
+      - base!=main
     actions:
       label:
         add:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -128,6 +128,13 @@ pull_request_rules:
       label:
         add:
           - PR stack
+  - name: toggle generator label
+    conditions:
+      - files~=turbo/generators/
+    actions:
+      label:
+        toggle:
+          - "feature: generator"
   # Partition rules
   # Would ideally have this as dynamic, but Mergify doesn't support the `partition-queue-name` attribute at the moment.
   - name: inkbeard partition workflow


### PR DESCRIPTION
<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira
INK-

## PR Notes
- This adds a label when the PR is updating a generator.
- This also looks at when the `base` branch is not `main` in order to add the `PR stack` label.