### PR TITLE
updated dependabot groups to have name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     ignore:
      - dependency-name: "typescript"
     groups:
-      dev-dependencies:
+      storybook:
         applies-to: version-updates
         patterns:
           - "@storybook*"


### PR DESCRIPTION
This pull request includes changes to the `.github/dependabot.yml` file to adjust the configuration for dependency updates. The most important change is the renaming and reconfiguration of a dependency group.

Configuration adjustments:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L15-R15): Renamed the `dev-dependencies` group to `storybook` and updated the patterns to apply to `@storybook*`

Change-Id: I545b41e4148ce207e8e0ad971aee3da3fccf69d5

<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira
INK-

## PR Notes
<!-- Add any relevant notes here. -->

<!-- Add indented breadcrumbs for any stacked PRs with an indicator for the current PR -->
<!--
## PR Stack
- #1
  - #2
    - #3 :point_left
-->