### PR TITLE
ignore @vue/eslint-config-typescript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
         versions: [">= 4"]
       - dependency-name: "vue-router"
         versions: ["<= 4.4.5"]
+      # ignore @vue/eslint-config-typescript since it's only supports flat config
+      - dependency-name: "@vue/eslint-config-typescript"
+        versions: [">= 14"]
     groups:
       storybook:
         applies-to: version-updates


### PR DESCRIPTION
<!-- depends-on: #42 -->
<!-- define PR dependencies with "depends-on" (https://docs.mergify.com/actions/merge/#defining-pull-request-dependencies) -->

## Jira

## PR Notes
Ignore @vue/eslint-config-typescript since it's for eslint v9 flat config.

> Dropped support for the legacy .eslintrc* configuration format. If you need that, please stay on version 13, which is also tagged as [@vue/eslint-config-typescript@legacy-eslintrc](https://www.npmjs.com/package/@vue/eslint-config-typescript/v/legacy-eslintrc).

https://github.com/vuejs/eslint-config-typescript/releases/tag/v14.0.0